### PR TITLE
add parameterized paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ gocks.exe
 .idea
 .project
 .settings
+
+# hide coverage reports
+cover*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A very lightweight and simple mocking service. The idea is that a JSON file conf
     - [Response Code](#response-code)
     - [Response Body](#response-body)
     - [Headers](#headers)
+- [Examples](#examples)
+  - [Hard coded response](#hard-coded-response)
+  - [Dynamic response](#dynamic-response)
+  - [With response headers](#with-response-headers)
 - [Build from source](#build-from-source)
 - [Run in Docker](#run-in-docker)
 - [Roadmap](#roadmap)
@@ -84,6 +88,83 @@ String representation of the response body. The response body will be sent regar
 
 #### Headers
 Headers to set in the response. You can use any string as a header key, and any string as a header value.
+
+## Examples
+
+### Hard coded response
+
+```json
+"mocks": [
+  {
+    "path":"/resource",
+    "method": "GET",
+    "response_code": 200,
+    "response_body": "this is a hard coded response"
+  }
+]
+```
+
+```
+$ curl localhost:8080/resource -i
+
+HTTP/1.1 200 OK
+Date: Sat, 02 Mar 2019 13:12:41 GMT
+Content-Length: 29
+Content-Type: text/plain; charset=utf-8
+
+this is a hard coded response
+```
+
+### Dynamic response
+```json
+"mocks": [
+  {
+    "path":"/users/{userid}",
+    "method":"GET",
+    "response_code": 200,
+    "response_body": "your id is {userid}"
+  }
+]
+```
+
+```
+$ curl localhost:8080/users/1337 -i
+
+HTTP/1.1 200 OK
+Date: Sat, 02 Mar 2019 13:14:34 GMT
+Content-Length: 15
+Content-Type: text/plain; charset=utf-8
+
+your id is 1337
+```
+
+### With response headers
+```json
+"mocks": [
+  {
+    "path":"/withheaders",
+    "method":"GET",
+    "response_code": 200,
+    "response_body": "a hardcoded response",
+    "headers": {
+      "Content-Type": "application/json",
+      "X-Custom-Header": "custom-header"
+    }
+  }
+]
+```
+
+```
+$ curl localhosi:8080/withheaders -i
+
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-Custom-Header: custom-header
+Date: Sat, 02 Mar 2019 13:15:52 GMT
+Content-Length: 20
+
+a hardcoded response
+```
 
 ## Build from source
 

--- a/handlers.go
+++ b/handlers.go
@@ -1,16 +1,33 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/hawry/gomocka/settings"
 )
 
 var availableHandlers []http.HandlerFunc
 
-func createHandler(code int, body string, headers map[string]string) http.HandlerFunc {
+func createHandler(code int, body string, headers map[string]string, m settings.Mock) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("debug: %s %s", r.Method, r.RequestURI)
+		b, wc := m.Wildcard()
+		if b {
+			vars := mux.Vars(r)
+			for _, s := range wc {
+				if val, ok := vars[s]; !ok {
+					continue
+				} else {
+					dc := fmt.Sprintf("{%s}", s)
+					body = strings.ReplaceAll(body, dc, val)
+				}
+			}
+		}
 
+		log.Printf("debug: %s %s", r.Method, r.RequestURI)
 		for k, v := range headers {
 			log.Printf("debug: adding %v, %v", k, v)
 			w.Header().Add(k, v)

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/gorilla/mux"
+	"github.com/hawry/gomocka/settings"
 
 	"comail.io/go/colog"
 
@@ -35,10 +36,10 @@ func main() {
 	}
 
 	if *generateConfig {
-		if err := createDefault(); err != nil {
+		if _, err := settings.CreateDefault(); err != nil {
 			log.Fatalf("error: %v", err)
 		}
-		fmt.Printf("example configuration created at %s\n", defaultGeneratedFile)
+		fmt.Printf("example configuration created\n")
 		return
 	}
 
@@ -48,7 +49,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
-	settings, err := NewSettings(f)
+	settings, err := settings.New(f)
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
@@ -75,12 +76,13 @@ func main() {
 	}
 }
 
-func setupHandlers(s *Settings, r *mux.Router) {
+func setupHandlers(s *settings.Settings, r *mux.Router) {
 	for _, m := range s.Mocks {
-		f := createHandler(m.ResponseCode, m.ResponseBody, m.Headers)
+		f := createHandler(m.ResponseCode, m.ResponseBody, m.Headers, m)
 		r.HandleFunc(m.Path, f).Methods(m.Method)
 		log.Printf("debug: creating mock for %s %s - returning %d, %s using %v", m.Method, m.Path, m.ResponseCode, m.ResponseBody, f)
 	}
+	log.Printf("info: registered %d paths", len(s.Mocks))
 }
 
 func initLogging() {
@@ -97,4 +99,8 @@ func initLogging() {
 		colog.SetMinLevel(colog.LInfo)
 	}
 	log.Printf("debug: enable verbose logging")
+}
+
+func doStuff() {
+	log.Printf("this is only here to test cover report")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestStuff(t *testing.T) {
+	t.Logf("yep")
+}

--- a/makefile
+++ b/makefile
@@ -18,5 +18,8 @@ run:
 clean:
 	rm -rf ./$(OUT)
 
+test:
+	go test ./... -v
+
 static:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $(OUT) $(LDFLAGS)

--- a/settings.json
+++ b/settings.json
@@ -2,20 +2,26 @@
   "port": 8080,
   "mocks": [
     {
-      "path":"/",
-      "method":"GET",
+      "path":"/resource",
+      "method": "GET",
       "response_code": 200,
-      "response_body": "{\"hello\":\"world\"}",
-      "headers": {
-        "Content-Type":"application/json",
-        "x-trace-id": "thisisatrace"
-      }
+      "response_body": "this is a hard coded response"
     },
     {
-      "path":"/hello",
-      "method":"POST",
-      "response_code": 400,
-      "response_body":"bad something"
+      "path":"/users/{userid}",
+      "method":"GET",
+      "response_code": 200,
+      "response_body": "your id is {userid}"
+    },
+    {
+      "path":"/withheaders",
+      "method":"GET",
+      "response_code": 200,
+      "response_body": "a hardcoded response",
+      "headers": {
+        "Content-Type": "application/json",
+        "X-Custom-Header": "custom-header"
+      }
     }
   ]
 }

--- a/settings/mock.go
+++ b/settings/mock.go
@@ -1,0 +1,28 @@
+package settings
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Mock describes what path that should return what status & body
+type Mock struct {
+	Path         string            `json:"path"`
+	Method       string            `json:"method"`
+	ResponseCode int               `json:"response_code"`
+	ResponseBody string            `json:"response_body"`
+	Headers      map[string]string `json:"headers"`
+}
+
+//Wildcard returns all possible wildcards in a path
+func (m *Mock) Wildcard() (bool, []string) {
+	r := regexp.MustCompile("{[[:alnum:]]*}")
+	matches := r.FindAllString(m.Path, -1)
+	mv := make([]string, len(matches))
+	for i, v := range matches {
+		v = strings.TrimPrefix(v, "{")
+		v = strings.TrimSuffix(v, "}")
+		mv[i] = v
+	}
+	return (len(mv) > 0), mv
+}

--- a/settings/mock_test.go
+++ b/settings/mock_test.go
@@ -1,0 +1,42 @@
+package settings
+
+import "testing"
+
+func TestSingleWildcard(t *testing.T) {
+	m := Mock{
+		Path: "/user/{userid}",
+	}
+	b, s := m.Wildcard()
+	if !b || (len(s) != 1) {
+		t.Fail()
+	}
+	for _, v := range s {
+		if v != "userid" {
+			t.Fail()
+		}
+	}
+}
+
+func TestMultipleWildcard(t *testing.T) {
+	m := Mock{
+		Path: "/user/{userid}/{more}",
+	}
+	b, s := m.Wildcard()
+	if !b || (len(s) != 2) {
+		t.Fail()
+	}
+	for _, v := range s {
+		if v != "userid" && v != "more" {
+			t.Fail()
+		}
+	}
+}
+
+func TestNoWildcard(t *testing.T) {
+	m := Mock{
+		Path: "/user/nothing",
+	}
+	if b, m := m.Wildcard(); b || (len(m) != 0) {
+		t.Fail()
+	}
+}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -1,4 +1,4 @@
-package main
+package settings
 
 import (
 	"encoding/json"
@@ -17,17 +17,8 @@ type Settings struct {
 	Mocks      []Mock `json:"mocks"`
 }
 
-// Mock describes what path that should return what status & body
-type Mock struct {
-	Path         string            `json:"path"`
-	Method       string            `json:"method"`
-	ResponseCode int               `json:"response_code"`
-	ResponseBody string            `json:"response_body"`
-	Headers      map[string]string `json:"headers"`
-}
-
-// NewSettings returns a new settings file containing the endpoints to mock
-func NewSettings(f *os.File) (s *Settings, err error) {
+//New returns a new configuration from the given file
+func New(f *os.File) (s *Settings, err error) {
 	b, err := ioutil.ReadAll(f)
 	if err != nil {
 		return
@@ -37,7 +28,7 @@ func NewSettings(f *os.File) (s *Settings, err error) {
 	return
 }
 
-// Port returns the set port number or returns the default port if none is set
+//Port returns the port number from the configuration, or a default port number if not set
 func (s *Settings) Port() int {
 	if s.ListenPort > 0 {
 		return s.ListenPort
@@ -45,10 +36,11 @@ func (s *Settings) Port() int {
 	return defaultPort
 }
 
-func createDefault() error {
+//CreateDefault creates a default configuration and returns the struct representation as well, default filename is example.json
+func CreateDefault() (*Settings, error) {
 	f, err := os.Create(defaultGeneratedFile)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	s := Settings{
 		ListenPort: 8080,
@@ -62,9 +54,16 @@ func createDefault() error {
 					"Content-Type": "application/json",
 				},
 			},
+			Mock{
+				Path:         "/users/{userid}",
+				Method:       "GET",
+				ResponseBody: "{\"user\":\"{userid}\"}",
+				ResponseCode: 200,
+			},
 		},
 	}
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "\t")
-	return enc.Encode(&s)
+	err = enc.Encode(&s)
+	return &s, err
 }


### PR DESCRIPTION
- parameters can be used in path configuration to match wildcards and to
dynamically create responses
- move settings to own package
- update readme to reflect latest changes