### PR TITLE
add test coverage report in makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GoMOCKA
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/hawry/gomocka)](https://goreportcard.com/report/github.com/hawry/gomocka) [![GoDoc](https://godoc.org/github.com/Hawry/gomocka?status.svg)](https://godoc.org/github.com/Hawry/gomocka)
+
 A very lightweight and simple mocking service. The idea is that a JSON file configures possible endpoints, and the service is either run locally or in a docker container.
 
 <!-- TOC depthFrom:2 -->

--- a/main.go
+++ b/main.go
@@ -100,7 +100,3 @@ func initLogging() {
 	}
 	log.Printf("debug: enable verbose logging")
 }
-
-func doStuff() {
-	log.Printf("this is only here to test cover report")
-}

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	"testing"
-)
-
-func TestStuff(t *testing.T) {
-	t.Logf("yep")
-}

--- a/makefile
+++ b/makefile
@@ -1,4 +1,5 @@
 OUT=gomocka
+PACKAGES = $(shell find ./ -type d -not -path '*/\.*')
 GITDESC=`git describe --always --tags`
 GITCOUNT=`git rev-list --count --first-parent HEAD`
 LDFLAGS=-ldflags "-X main.buildVersion=$(GITDESC)-$(GITCOUNT)"
@@ -23,3 +24,10 @@ test:
 
 static:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $(OUT) $(LDFLAGS)
+
+report:
+	echo "mode: count" > coverage-all.out
+	$(foreach pkg,$(PACKAGES),\
+		go test -coverprofile=coverage.out -covermode=count $(pkg);\
+		tail -n +2 coverage.out >> coverage-all.out;)
+	BROWSER=firefox go tool cover -html=coverage-all.out


### PR DESCRIPTION
- run `make report` to run all tests and open the test coverage report
- add badges to readme